### PR TITLE
Fix crash if adapter is empty

### DIFF
--- a/StackLayoutManager/src/main/java/com/littlemango/stacklayoutmanager/StackLayoutManager.kt
+++ b/StackLayoutManager/src/main/java/com/littlemango/stacklayoutmanager/StackLayoutManager.kt
@@ -278,6 +278,10 @@ class StackLayoutManager(scrollOrientation: ScrollOrientation,
     }
 
     override fun onLayoutChildren(recycler: RecyclerView.Recycler, state: RecyclerView.State) {
+        if (itemCount == 0) {
+            return
+        }
+
         mLayout?.requestLayout()
 
         removeAndRecycleAllViews(recycler)


### PR DESCRIPTION
If adapter doesn't have any items yet (very common if data is coming from network), it will crash with
`java.lang.IndexOutOfBoundsException: Invalid item position -1(-1). Item count:0`.