### PR TITLE
Fix on items not being removed and crash on scroll

### DIFF
--- a/StackLayoutManager/src/main/java/com/littlemango/stacklayoutmanager/StackLayoutManager.kt
+++ b/StackLayoutManager/src/main/java/com/littlemango/stacklayoutmanager/StackLayoutManager.kt
@@ -264,31 +264,35 @@ class StackLayoutManager(scrollOrientation: ScrollOrientation,
     }
 
     override fun canScrollHorizontally(): Boolean {
-        return when(mScrollOrientation) {
+        if (itemCount == 0) {
+            return false
+        }
+        return when (mScrollOrientation) {
             ScrollOrientation.LEFT_TO_RIGHT, ScrollOrientation.RIGHT_TO_LEFT -> true
             else -> false
         }
     }
 
     override fun canScrollVertically(): Boolean {
-        return when(mScrollOrientation) {
+        if (itemCount == 0) {
+            return false
+        }
+        return when (mScrollOrientation) {
             ScrollOrientation.TOP_TO_BOTTOM, ScrollOrientation.BOTTOM_TO_TOP -> true
             else -> false
         }
     }
 
     override fun onLayoutChildren(recycler: RecyclerView.Recycler, state: RecyclerView.State) {
-        if (itemCount == 0) {
-            return
-        }
 
         mLayout?.requestLayout()
 
         removeAndRecycleAllViews(recycler)
 
-        mScrollOffset = getValidOffset(mScrollOffset)
-
-        loadItemView(recycler)
+        if (itemCount > 0) {
+            mScrollOffset = getValidOffset(mScrollOffset)
+            loadItemView(recycler)
+        }
     }
 
     override fun scrollHorizontallyBy(dx: Int, recycler: RecyclerView.Recycler, state: RecyclerView.State): Int {


### PR DESCRIPTION
This pull fixes two issues:

1. Items were not removed from the RecyclerView because the zero check was before removing all views.

2. Crash on scroll when there are 0 items. This is because the scroll offset calculation determined that the items had to be laid uit, but because there were 0 items, the RecyclerView crashed when asking for the view for the -1 position.